### PR TITLE
Bump the nice-to-have group with 3 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "@angular/compiler": "9.0.0",
         "@angular/core": "10.0.0",
         "@angular/forms": "13.0.0",
-        "@ngrx/effects": "^17.0.2",
-        "@ngrx/operators": "^17.0.0",
-        "@ngrx/signals": "^17.0.0",
+        "@ngrx/effects": "^19.1.0",
+        "@ngrx/operators": "^19.1.0",
+        "@ngrx/signals": "^19.1.0",
         "karma": "5.0.0",
         "karma-chrome-launcher": "2.0.0",
         "karma-coverage": "2.0.0",
@@ -48,12 +48,6 @@
         "npm": ">=2.0.0"
       }
     },
-    "node_modules/@angular-devkit/architect/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
     "node_modules/@angular-devkit/core": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.0.6.tgz",
@@ -83,12 +77,6 @@
         "npm": ">=2.0.0"
       }
     },
-    "node_modules/@angular-devkit/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
     "node_modules/@angular-devkit/schematics": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.0.6.tgz",
@@ -114,12 +102,6 @@
       "engines": {
         "npm": ">=2.0.0"
       }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/@angular/cli": {
       "version": "8.0.6",
@@ -154,6 +136,30 @@
         "npm": ">= 6.2.0"
       }
     },
+    "node_modules/@angular/common": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-13.0.0.tgz",
+      "integrity": "sha512-7KNu6fcNeX71nrOAs29T/PGdO0fAHaX0mtmobIBeIwMF9qY1fqc7a1Rssp6/dUe9XlADf2sXVtx5ZQ8c6bAMsA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "13.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/common/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
     "node_modules/@angular/compiler": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
@@ -176,6 +182,12 @@
         "zone.js": "~0.10.3"
       }
     },
+    "node_modules/@angular/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@angular/forms": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-13.0.0.tgz",
@@ -193,6 +205,42 @@
         "@angular/platform-browser": "13.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
+    },
+    "node_modules/@angular/forms/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@angular/platform-browser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-13.0.0.tgz",
+      "integrity": "sha512-3svk0R9UVDL0600Lf5sfFKcOrduKU17UIqrXm+iN0EBGCGostKfQb+GCFPJVZ0wUFJuXyHGovESIJX85uGhpHA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "13.0.0",
+        "@angular/common": "13.0.0",
+        "@angular/core": "13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/animations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/platform-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
@@ -351,36 +399,29 @@
       }
     },
     "node_modules/@ngrx/effects": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-17.2.0.tgz",
-      "integrity": "sha512-tXDJNsuBtbvI/7+vYnkDKKpUvLbopw1U5G6LoPnKNrbTPsPcUGmCqF5Su/ZoRN3BhXjt2j+eoeVdpBkxdxMRgg==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-19.1.0.tgz",
+      "integrity": "sha512-rGRN0ZnzAPmQdUPvmoqZsK7Da/AoCfQcfody+h6PfHTwXNm+M2MRc8tXO6C+fznMRww8ZgNror2dfFmoOSOvNg==",
       "license": "MIT",
       "dependencies": {
-        "@ngrx/operators": "17.0.0-beta.0",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.0",
-        "@ngrx/store": "17.2.0",
+        "@angular/core": "^19.0.0",
+        "@ngrx/store": "19.1.0",
         "rxjs": "^6.5.3 || ^7.5.0"
       }
     },
-    "node_modules/@ngrx/effects/node_modules/@ngrx/operators": {
-      "version": "17.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/operators/-/operators-17.0.0-beta.0.tgz",
-      "integrity": "sha512-EbO8AONuQ6zo2v/mPyBOi4y0CTAp1x4Z+bx7ZF+Pd8BL5ma53BTCL1TmzaeK5zPUe0yApudLk9/ZbHXPnVox5A==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
+    "node_modules/@ngrx/effects/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@ngrx/operators": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/operators/-/operators-17.2.0.tgz",
-      "integrity": "sha512-W7SrGK4VQSJlCtMrkxNChVBDgJGSCdZ4yLBi80xoE9CmhTMMhu9J+8BbDDhZ+PPbTHylKJobkwHq+tJ8mkf4eQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/operators/-/operators-19.1.0.tgz",
+      "integrity": "sha512-gpo69FnoAF69X68pk9eWFHB630xqerBYkF68wOFMciLOV2im3b/fAf+0sRvnQJmVtG/8jO0IPVdvLqa1TbWmPA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -389,16 +430,22 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
+    "node_modules/@ngrx/operators/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@ngrx/signals": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-17.2.0.tgz",
-      "integrity": "sha512-tkkxifeOVPOhpTqbHyK1WOx4qz49HLR/h0vhaa/MRGRIZoOR/6gR4KB3hbC8FD3FdnuNqOgOZ2lGsTfWPB/6BQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-19.1.0.tgz",
+      "integrity": "sha512-v8sbb+Iox9kdIaKbFgt4Z1W+NxzIU4+g+6qQU6/c27UmtQXv0s1zUKKofPRK0qwkaZzNWkxNToxyoE285ukqcQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/core": "^17.0.0",
+        "@angular/core": "^19.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       },
       "peerDependenciesMeta": {
@@ -406,6 +453,33 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ngrx/signals/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@ngrx/store": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-19.1.0.tgz",
+      "integrity": "sha512-8kKCSFahTpRTx3f/wwcDjItdFnk2IMoorWRjTI2U/MGWuEi4flqLNWcX99s759e7TI6PctiGsaS8jnJXIUS8Jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^19.0.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/store/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@schematics/angular": {
       "version": "8.0.6",
@@ -453,12 +527,6 @@
       "engines": {
         "npm": ">=2.0.0"
       }
-    },
-    "node_modules/@schematics/update/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -4296,12 +4364,6 @@
         "npm": ">=2.0.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4985,9 +5047,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
@@ -5487,6 +5549,13 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==",
       "license": "MIT"
+    },
+    "node_modules/zone.js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
+      "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "@angular/core": "10.0.0",
     "@angular/forms": "13.0.0",
     "lodash": "3.0.0",
-    "@ngrx/effects": "^17.0.2",
-    "@ngrx/operators": "^17.0.0",
-    "@ngrx/signals": "^17.0.0",
+    "@ngrx/effects": "^19.1.0",
+    "@ngrx/operators": "^19.1.0",
+    "@ngrx/signals": "^19.1.0",
     "karma": "5.0.0",
     "karma-chrome-launcher": "2.0.0",
     "karma-coverage": "2.0.0"


### PR DESCRIPTION
Bumps the nice-to-have group with 3 updates: [@ngrx/effects](https://github.com/ngrx/platform), [@ngrx/operators](https://github.com/ngrx/platform) and [@ngrx/signals](https://github.com/ngrx/platform).


Updates `@ngrx/effects` from 17.2.0 to 19.1.0
- [Changelog](https://github.com/ngrx/platform/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ngrx/platform/compare/17.2.0...19.1.0)

Updates `@ngrx/operators` from 17.2.0 to 19.1.0
- [Changelog](https://github.com/ngrx/platform/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ngrx/platform/compare/17.2.0...19.1.0)

Updates `@ngrx/signals` from 17.2.0 to 19.1.0
- [Changelog](https://github.com/ngrx/platform/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ngrx/platform/compare/17.2.0...19.1.0)

---
updated-dependencies:
- dependency-name: "@ngrx/effects" dependency-version: 19.1.0 dependency-type: direct:production update-type: version-update:semver-major dependency-group: nice-to-have
- dependency-name: "@ngrx/operators" dependency-version: 19.1.0 dependency-type: direct:production update-type: version-update:semver-major dependency-group: nice-to-have
- dependency-name: "@ngrx/signals" dependency-version: 19.1.0 dependency-type: direct:production update-type: version-update:semver-major dependency-group: nice-to-have ...